### PR TITLE
Navbar naming fix for dicas-de-inverno.md

### DIFF
--- a/vida/dicas-de-inverno.md
+++ b/vida/dicas-de-inverno.md
@@ -1,5 +1,5 @@
 ---
-title: Trabalho Remoto
+title: Dicas de Inverno
 parent: Vida no Canadá
 ---
 


### PR DESCRIPTION
Item da Navbar `Trabalho Remoto` deveria ser `Dicas de Inverno`:

![image](https://github.com/user-attachments/assets/3904f9ac-c019-4cb5-be81-da9cdf85bde6)
